### PR TITLE
Update dependencies in pubspec.yaml and modify logger error handling

### DIFF
--- a/lib/src/util/logger.dart
+++ b/lib/src/util/logger.dart
@@ -52,5 +52,5 @@ void error(
     tagStr += '(${object.runtimeType.toString()})';
   }
 
-  _logger.e('$tagStr: ${message ?? ''}', err, trace);
+  _logger.e('$tagStr: ${message ?? ''}', error: err, stackTrace: trace);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flow_graph
 description: DAG graph on flutter.
-version: 0.0.10
+version: 0.0.11
 repository: https://github.com/youngchan1988/flow_graph
 issue_tracker: https://github.com/youngchan1988/flow_graph/issues
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  collection: ^1.15.0
-  ulid: ^2.0.0
-  logger: ^1.1.0
+  collection: ^1.19.0
+  ulid: ^2.0.1
+  logger: ^2.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request includes a version update for the `flow_graph` package and refactors the `error` logging method in `logger.dart`. Additionally, it updates several dependencies in `pubspec.yaml` to newer versions.

### Version and Dependency Updates:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R3): Updated the package version from `0.0.10` to `0.0.11`.
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L14-R16): Upgraded dependencies: `collection` to `^1.19.0`, `ulid` to `^2.0.1`, and `logger` to `^2.5.0`.

### Code Refactor:
* [`lib/src/util/logger.dart`](diffhunk://#diff-45af1bf3d2cb1eafef3890261d0873224e81b841fc526f3a383eb123b7adc543L55-R55): Refactored the `error` method to use named parameters (`error` and `stackTrace`) for improved clarity and compatibility with the updated `logger` package.